### PR TITLE
Make sure search bar doesn't overflow on low-res screens

### DIFF
--- a/web/static/css/fame.css
+++ b/web/static/css/fame.css
@@ -529,9 +529,10 @@ td > .small {
   padding-top: 40px;
 }
 
-.navbar-form {
-    height: 30px;
-    width: 900px;
+@media(min-width:1637px) {
+ .navbar-search-form {
+   width: 900px;
+ }
 }
 
 .navbar-form .input-group {

--- a/web/static/css/template.css
+++ b/web/static/css/template.css
@@ -1610,11 +1610,11 @@ body > .navbar-collapse[data-color="purple"]:after {
   padding: 0;
   background-color: transparent;
   height: 30px;
-  width: 900px;
   font-size: 16px;
   line-height: 1.5;
   color: #E3E3E3;
 }
+
 .navbar-transparent .navbar-form .form-control, [class*="navbar-ct"] .navbar-form .form-control {
   color: #FFFFFF;
   border: 0;

--- a/web/templates/analyses/show.html
+++ b/web/templates/analyses/show.html
@@ -84,7 +84,6 @@ Analysis
     </a>
 </li>
 {% endif %}
-
 {% endblock %}
 
 {% block body %}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -140,7 +140,7 @@
                 </div>
                 <div class="collapse navbar-collapse">
                     <form class="navbar-form navbar-left navbar-search-form" role="search" action="{{ url_for('SearchView:post') }}" method="post">
-                        <div class="input-group" style="width: 100%;">
+                        <div class="input-group">
                             <span class="input-group-addon"><i class="fa fa-search"></i></span>
                             <input type="text" name="query" value="" class="form-control" placeholder="Search...">
                         </div>


### PR DESCRIPTION
When the screen has a low resolution (less than 1637px), the new width applied to the searchbar causes the left menu to be moved to a new line

![image](https://github.com/user-attachments/assets/0910d5a6-eced-4e6f-ab78-5594a8e7c5f9)

Hence, locking the menu size change to screens >=1637px